### PR TITLE
Use current-column for column of point

### DIFF
--- a/parinfer-mode.el
+++ b/parinfer-mode.el
@@ -34,13 +34,13 @@
 (defun parinfer-mode-indent-mode ()
   (parinfer-mode-post "http://localhost:8088/indent-mode"
                       (buffer-string)
-                      (column-number-at-pos (point))
+                      (current-column)
                       (- (line-number-at-pos) 1)))
 
 (defun parinfer-mode-paren-mode ()
   (parinfer-mode-post "http://localhost:8088/paren-mode"
                       (buffer-string)
-                      (column-number-at-pos (point))
+                      (current-column)
                       (- (line-number-at-pos) 1)))
 
 (define-minor-mode parinfer-mode


### PR DESCRIPTION
At first glance of the api it looks like parifner only ever uses the current column of the point - I don't think `column-number-at-pos` is in emacs core so this changes it to use `current-column`
